### PR TITLE
chore: add attributes for data hook on header, footer, and page type in layout

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -7,7 +7,7 @@
     {{ head_content }}
     <style>.preloader * { opacity: 0; }.transition-preloader * { transition: none !important }</style>
   </head>
-  <body id="{{ page.permalink }}" class="{{ page.category }} preloader transition-preloader">
+  <body id="{{ page.permalink }}" class="{{ page.category }} preloader transition-preloader" data-bc-page-type="{% if page.category == 'custom' %}custom{% else %}{{ page.permalink }}{% endif %}">
     <a class="skip-link" href="#main">Skip to main content</a>
     {% if theme.announcement_message_text != blank %}
       <div aria-label="Announcement message" class="announcement-message">
@@ -141,7 +141,7 @@
         </a>
       </div>
     </div>
-    <header>
+    <header data-bc-hook="header">
       <a href="/" title="{{ store.name | escape }}" class="header-store-link header-store-link--{% if theme.header_logo != blank %}logo{% else %}text{% endif %}">
         {% if theme.logo_image != blank %}
           {% assign logo_image_height_1x = theme.logo_image_height %}
@@ -169,7 +169,7 @@
         {% endif %}
       </div>
     </main>
-    <footer>
+    <footer data-bc-hook="footer">
       <nav class="footer-nav--links" aria-label="Secondary">
         <ul>
           <li><a href="/">{{ pages.home.name }}</a></li>

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Cosmos",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "images": [
     {
       "variable": "logo_image",


### PR DESCRIPTION
Allows for 3rd party apps to target key regions for adding content. In particular, key for omnisend and email partners to be able to insert content above the footer.

1. Adds `data-bc-hook` attribute to header and footer
2. Adds `data-bc-page-type` attribute to the body tag

Note: A much larger change was previously proposed but I've scaled it back to only the above 2 changes foregoing the larger change which is much more complex.
