### PR TITLE
v1.2.2

### DIFF
--- a/source/product.html
+++ b/source/product.html
@@ -235,7 +235,7 @@
                       "
                       data-sizes="auto"
                     >
-                    {% if product_status != blank %}<div class="product-list-thumb-status">{{ product_status }}</div>{% endif %}
+                    {% if product_status != blank %}<div class="product-list-thumb-status {{ status_class }}">{{ product_status }}</div>{% endif %}
                   </div>
                   <div class="product-list-thumb-info">
                     <div class="product-list-thumb-name">{{ product.name }}</div>

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Cosmos",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "images": [
     {
       "variable": "logo_image",
@@ -273,7 +273,7 @@
               "secondary_font": "Source Code Pro"
             },
             "colors": {
-              "background_color": "#222222",
+              "background_color": "#000000",
               "text_color": "#DDDDDD",
               "link_text_color": "#DDDDDD",
               "link_hover_color": "#E7E71C",
@@ -282,13 +282,13 @@
               "border_color": "#4E4E4E",
               "button_background_color": "#E7E71C",
               "button_hover_background_color": "#C5C519",
-              "button_text_color": "#222222",
+              "button_text_color": "#000000",
               "announcement_background_color": "#1C71E7",
               "announcement_text_color": "#DDDDDD",
-              "product_status_text_color": "#222222",
-              "product_status_background_color": "#E7E71C",
-              "product_status_text_color_secondary": "#222222",
-              "product_status_background_color_secondary": "#DDDDDD",
+              "product_status_text_color": "#E7E71C",
+              "product_status_background_color": "#3F3F3F",
+              "product_status_text_color_secondary": "#DDDDDD",
+              "product_status_background_color_secondary": "#414141",
               "hero_overlay_color": "#4E4E4E",
               "hero_text_color": "#DDDDDD",
               "product_hover_overlay_color": "#4E4E4E",

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -65,6 +65,7 @@ a
 
   &:hover
     text-decoration: underline
+    text-underline-offset: 3px
 
 a.skip-link
   transition: top .2s ease
@@ -74,7 +75,8 @@ a.skip-link
   left: 24px
   padding: 16px 24px
   position: absolute
-  text-decoration: underline
+  text-decoration: underline  
+  text-underline-offset: 3px
   top: -150px
   z-index: 100
 
@@ -93,6 +95,10 @@ header
   text-align: center
   width: 100%
   margin: 0 auto
+
+  a
+    &:hover
+      text-decoration: none
 
   @media screen and (max-width: $break-small)
     --side-padding: 16px
@@ -124,8 +130,7 @@ header
       text-decoration: none
 
     &:hover
-      border-bottom: 2px solid var(--link-hover-color)
-
+      border-bottom: 1px solid var(--link-hover-color)
   &--links
     @media screen and (max-width: $break-small)
       display: none
@@ -266,6 +271,9 @@ footer
       a
         display: block
 
+        &:hover
+          text-underline-offset: 3px
+
       @media screen and (max-width: $break-small)
         flex-direction: column
         row-gap: 24px
@@ -289,6 +297,9 @@ footer
     padding-top: 1px
     width: 80px
 
+  &:hover
+    text-decoration: none
+
 .custom-page--content, .product-detail__description
 
   p
@@ -311,6 +322,7 @@ footer
 
   a
     text-decoration: underline
+    text-underline-offset: 3px
 
 .select
   border-radius: var(--border-radius)
@@ -427,6 +439,7 @@ button.button, a.button, div.button
     border: 0
     color: var(--text-color)
     text-decoration: underline
+    text-underline-offset: 3px
     font-weight: normal
 
     &:hover, &:focus

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -11,7 +11,11 @@
   margin-bottom: 24px
 
   a
-    text-decoration: underline
+    text-decoration: none
+
+    &:hover
+      text-decoration: underline
+      text-underline-offset: 3px
 
 .reset-selection-button-container
   text-align: center
@@ -83,7 +87,10 @@
   .related-products-view-all-link
     margin-left: auto
     font-weight: 700
-    text-decoration: underline
+
+    &:hover
+      text-decoration: underline
+      text-underline-offset: 3px
 
 .related-product-list
   --columns: 4


### PR DESCRIPTION
* fix: background colors on Playful preset 1 for more contrast
* fix: product status badge on related items uses the primary and second background colors
* chore: removed unnecessary line underlines on non-hover states