### PR TITLE
fix: set valid default for hero overlay opacity setting

### DIFF
--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Cosmos",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "images": [
     {
       "variable": "logo_image",
@@ -695,7 +695,7 @@
         ["Dark", "dark"],
         ["Very dark", "very_dark"]
       ],
-      "default": "0.50",
+      "default": "none",
       "description": "Adjust the home page slideshow or hero image to enhance the legibility of your hero text and button"
     },
     {


### PR DESCRIPTION
When making changes to the hero overlay opacity, I accidentally left the default value as `0.5` which isn't valid anymroe as we've moved to description values like `none` and `bright`.