### PR TITLE
Cosmos 1.8.1

### DIFF
--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Cosmos",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "images": [
     {
       "variable": "logo_image",

--- a/source/settings.json
+++ b/source/settings.json
@@ -1795,6 +1795,7 @@
       "section": "translations",
       "sub_section": "cart",
       "type": "text",
+      "max_length": 250,
       "default": "Your cart is empty",
       "description": "Text for the empty cart message",
       "requires": [ "translation_mode eq manual" ]

--- a/source/stylesheets/home.sass
+++ b/source/stylesheets/home.sass
@@ -37,10 +37,16 @@
       max-width: 100%
 
   &--constrained
+    max-width: calc(1080px + calc(var(--side-padding) * 2))
+    margin-left: auto
+    margin-right: auto
     border-radius: var(--border-radius)
 
     @media screen and (max-width: $break-small)
       border-radius: 0
+      margin-left: var(--side-padding)
+      margin-right: var(--side-padding)
+      max-width: none
 
     .home-hero-content, .home-hero-overlay, .home-hero-image
       border-radius: var(--border-radius)


### PR DESCRIPTION
- fix: homepage hero image "constrained" width works
- chore: increase empty cart text msg up to 250 chars from 30