### PR TITLE
Cosmos 1.10.1

### DIFF
--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Cosmos",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "images": [
     {
       "variable": "logo_image",

--- a/source/settings.json
+++ b/source/settings.json
@@ -1777,6 +1777,26 @@
       "requires": [ "translation_mode eq manual" ]
     },
     {
+      "variable": "products_product_tr_text",
+      "label": "'Product'",
+      "section": "translations",
+      "sub_section": "products",
+      "type": "text",
+      "default": "Product",
+      "description": "Text displayed when referencing a single item in your shop",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "products_products_tr_text",
+      "label": "'Products'",
+      "section": "translations",
+      "sub_section": "products",
+      "type": "text",
+      "default": "Products",
+      "description": "Text displayed when referencing multiple items in your shop",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
       "variable": "products_related_products_tr_text",
       "label": "Related products header",
       "section": "translations",

--- a/source/settings.json
+++ b/source/settings.json
@@ -1648,7 +1648,7 @@
       "section": "translations",
       "sub_section": "homepage",
       "type": "text",
-      "default": "Featured categories",
+      "default": "Shop by Category",
       "allow_blank": true,
       "description": "Text for the featured categories section on the home page.",
       "requires": [ "translation_mode eq manual" ]

--- a/source/settings.json
+++ b/source/settings.json
@@ -1240,7 +1240,8 @@
       "label": "Show product variant count in product grids",
       "section": "product_page",
       "type": "boolean",
-      "default": false,
+      "default": true,
+      "upgrade_default": false,
       "description": "For products with multiple variants, show the variant count in product grids."
     },
     {


### PR DESCRIPTION
- chore: show variant count in product grid by default only for new themes
- chore: update featured categories default text
- chore: settings for product(s) label translations