### PR TITLE
Cosmos 1.10.3

### DIFF
--- a/source/home.html
+++ b/source/home.html
@@ -237,10 +237,10 @@
                       {% endif %}
                     {% endcapture %}
 
-                    <div class="product-list-image-container product-list-image-container-cover">
+                    <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
                       <img
                         alt=""
-                        class="blur-up product-list-image lazyload grid-cover"
+                        class="blur-up product-list-image lazyload grid-{{ theme.grid_image_style }}"
                         src="{{ product.image | product_image_url | constrain: 20 }}"
                         {% unless theme.grid_image_style == 'default' %}data-aspectratio="{{ aspect_ratio }}"{% endunless %}
                         data-srcset="
@@ -291,7 +291,7 @@
                     {% endif %}
 
                     <div
-                      class="product-list-image-container product-list-image-container-cover" 
+                      class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}" 
                       id="category-collage-{{ category.id }}"
                       data-image-urls='{{ image_urls | strip }}'
                       data-image-style="{{ theme.home_page_categories_image_style }}"
@@ -299,7 +299,7 @@
                       <!-- Default placeholder while image is being loaded -->
                       <img
                         alt=""
-                        class="blur-up product-list-image lazyload grid-cover"
+                        class="blur-up product-list-image lazyload grid-{{ theme.grid_image_style }}"
                         src="{{ first_product.image | product_image_url | constrain: 30 }}"
                         {% unless theme.grid_image_style == 'default' %}data-aspectratio="{{ aspect_ratio }}"{% endunless %}
                       >

--- a/source/home.html
+++ b/source/home.html
@@ -185,21 +185,20 @@
                   </a>
                 </div>
               {% endfor %}
-            </div>
           </div>
-          {% if paginate.pages > 1 %}
-            {% assign all_products_button_text = t['navigation.all_products'] %}
-            {% if all_products_button_text != blank %}
-              <a class="button button--centered button--secondary all-products-button" href="/products">{{ all_products_button_text }}</a>  
-            {% endif %}
-          {% endif %}
+        </div>
         {% else %}
           <div class="message-banner message-banner--centered message-banner--no-bg">{{ t['products.no_products'] }}</div>
         {% endif %}
       {% endpaginate %}
     {% endif %}
   </div>
-  {% if theme.show_home_page_categories and categories.active.size > 0 %}
+  {%- assign fc_num = theme.featured_categories | plus: 0 -%}
+  {%- assign can_show_categories = false -%}
+  {%- if theme.show_home_page_categories and fc_num > 0 and categories.active.size > 0 -%}
+    {%- assign can_show_categories = true -%}
+  {%- endif -%}
+  {% if can_show_categories %}
     {% assign category_collages_enabled = false %}
     {% if theme.features.has_theme_category_collages %}
       {% assign category_collages_enabled = true %}
@@ -321,4 +320,18 @@
       </div>
     </div>
   {% endif %}
+
+  {%- comment -%}
+    All products button should appear after the last featured section
+    - After categories if both are shown
+    - After products if only products are shown
+    - After categories if only categories are shown
+  {%- endcomment -%}
+  {%- assign show_featured_products = theme.featured_products > 0 and products.all.size > 0 -%}
+  {%- if (can_show_categories or show_featured_products) and products.all.size > 0 -%}
+    {%- assign all_products_button_text = t['navigation.all_products'] -%}
+    {%- if all_products_button_text != blank -%}
+      <a class="button button--centered button--secondary all-products-button" href="/products">{{ all_products_button_text }}</a>
+    {%- endif -%}
+  {%- endif -%}
 </div>

--- a/source/javascripts/image-collage.js
+++ b/source/javascripts/image-collage.js
@@ -1198,6 +1198,17 @@ function processContainer(container, collageOptions = {}) {
     return;
   }
 
+  // If only one image, use original URL directly - let CSS handle object-fit for themes that support it
+  if (imageUrls.length === 1) {
+    const img = container.querySelector('img');
+    if (img) {
+      img.src = imageUrls[0];
+      img.classList.remove('loading');
+      img.classList.add('lazyloaded');
+    }
+    return;
+  }
+
   // Validate and sanitize layout type
   let layoutType;
   if (COLLAGE_CONFIG.VALID_LAYOUT_TYPES.includes(imageStyle)) {

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Cosmos",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "images": [
     {
       "variable": "logo_image",

--- a/source/stylesheets/products.sass
+++ b/source/stylesheets/products.sass
@@ -225,6 +225,8 @@ a.product-list-link
 
 // Featured Categories: when grid_image_style is default, keep category thumbs square and contained
 .featured-categories
+  margin-bottom: calc(var(--margin-size) * 1.5)
+
   .product-list-image-container-default
     padding-bottom: 100%
 

--- a/source/stylesheets/products.sass
+++ b/source/stylesheets/products.sass
@@ -223,6 +223,15 @@ a.product-list-link
   &.grid-contain
     object-fit: contain
 
+// Featured Categories: when grid_image_style is default, keep category thumbs square and contained
+.featured-categories
+  .product-list-image-container-default
+    padding-bottom: 100%
+
+  .product-list-image.grid-default
+    position: absolute
+    object-fit: contain
+
 .product-list-thumb-status
   border-radius: var(--border-radius-sm)
   top: 16px


### PR DESCRIPTION
- fix: correctly handle single image categories for collages and the grid image style
- chore: move all products to bottom of homepage instead of always just after featured products