### PR TITLE
Cosmos v1.10.5

### DIFF
--- a/source/home.html
+++ b/source/home.html
@@ -194,7 +194,7 @@
     {% endif %}
   </div>
   {%- assign can_show_categories = false -%}
-  {%- if theme.show_home_page_categories and theme.featured_categories > 0 and categories.active.size > 0 -%}
+  {%- if theme.featured_categories > 0 and categories.active.size > 0 -%}
     {%- assign can_show_categories = true -%}
   {%- endif -%}
   {% if can_show_categories %}
@@ -334,9 +334,11 @@
   {%- if products.all.size > 0 -%}
     {%- if can_show_categories or show_featured_products -%}
       {%- unless theme.featured_products == 0 and theme.featured_categories == 0 -%}
-        {%- assign all_products_button_text = t['navigation.all_products'] -%}
-        {%- if all_products_button_text != blank -%}
-          <a class="button button--centered button--secondary all-products-button" href="/products">{{ all_products_button_text }}</a>
+        {%- if theme.homepage_show_all_items_link -%}
+          {%- assign all_products_button_text = t['navigation.all_products'] -%}
+          {%- if all_products_button_text != blank -%}
+            <a class="button button--centered button--secondary all-products-button" href="/products">{{ all_products_button_text }}</a>
+          {%- endif -%}
         {%- endif -%}
       {%- endunless -%}
     {%- endif -%}

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Cosmos",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "images": [
     {
       "variable": "logo_image",
@@ -727,7 +727,7 @@
       "default": 3,
       "description": "The maximum number of Home page categories displayed per row",
       "requires": [
-        "show_home_page_categories eq true"
+        "featured_categories gt 0"
       ]
     },
     {
@@ -1116,24 +1116,13 @@
       ]
     },
     {
-      "variable": "show_home_page_categories",
-      "label": "Display categories on Home page",
-      "section": "homepage",
-      "type": "boolean",
-      "default": true,
-      "description": "Displays categories as a grid on the Home page"
-    },
-    {
       "variable": "featured_categories",
       "label": "Featured categories",
       "section": "homepage",
       "type": "select",
-      "options": "1..48",
-      "default": 12,
-      "description": "The number of categories displayed on the Home page",
-      "requires": [
-        "show_home_page_categories eq true"
-      ]
+      "options": "0..48",
+      "default": 0,
+      "description": "The number of categories displayed on the Home page"
     },
     {
       "variable": "home_page_categories_style",
@@ -1147,7 +1136,7 @@
       "default": "thumbnails",
       "description": "Sets the display of images in the product grid",
       "requires": [
-        "show_home_page_categories eq true"
+        "featured_categories gt 0"
       ]
     },
     {
@@ -1166,7 +1155,7 @@
       "description": "Choose layout style for category images on the Home page",
       "requires": [
         "feature:theme_category_collages eq visible",
-        "show_home_page_categories eq true",
+        "featured_categories gt 0",
         "home_page_categories_style eq thumbnails"
       ]
     },
@@ -1179,7 +1168,7 @@
       "description": "Display the number of products next to each category name",
       "requires": [
         "feature:theme_category_collages eq visible",
-        "show_home_page_categories eq true",
+        "featured_categories gt 0",
         "home_page_categories_style eq thumbnails"
       ]
     },
@@ -1195,9 +1184,17 @@
       "default": "under_image",
       "description": "Shows a category’s name over the image with an overlay, or under the image",
       "requires": [
-        "show_home_page_categories eq true",
+        "featured_categories gt 0",
         "home_page_categories_style eq thumbnails"
       ]
+    },
+    {
+      "variable": "homepage_show_all_items_link",
+      "label": "Show all items link",
+      "section": "homepage",
+      "type": "boolean",
+      "default": true,
+      "description": "Display link to view all products when applicable"
     },
     {
       "variable": "money_format",

--- a/source/settings.json
+++ b/source/settings.json
@@ -1190,11 +1190,11 @@
     },
     {
       "variable": "homepage_show_all_items_link",
-      "label": "Show all items link",
+      "label": "Show all products button",
       "section": "homepage",
       "type": "boolean",
       "default": true,
-      "description": "Display link to view all products when applicable"
+      "description": "Allow the 'All products' button to show on the Home page when eligible"
     },
     {
       "variable": "money_format",


### PR DESCRIPTION
- feat: add `homepage_show_all_items_link` to control all products link appearing on homepage
- chore: drop `show_home_page_categories` setting in favor of just using `featured_categories` for simplicity 