### PR TITLE
Cosmos v1.12.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ log
 *.tmproj
 *.esproj
 *.sublime*
+
+tags

--- a/source/cart.html
+++ b/source/cart.html
@@ -49,7 +49,19 @@
                     {{ item.option.name }}
                   </div>
                 {% endunless %}
-                <div class="cart-item-unit-price">{{ item.unit_price | money: theme.money_format }}</div>
+                <div class="cart-item-unit-price">
+                  {% assign show_strikethrough = false %}
+                  {% if theme.show_strikethrough_pricing and item.original_unit_price > item.unit_price %}
+                    {% assign show_strikethrough = true %}
+                  {% endif %}
+
+                  {% if show_strikethrough %}
+                    <s class="price-compare">{{ item.original_unit_price | money: theme.money_format }}</s>
+                    <span class="price-sale">{{ item.unit_price | money: theme.money_format }}</span>
+                  {% else %}
+                    {{ item.unit_price | money: theme.money_format }}
+                  {% endif %}
+                </div>
               </div>
 
               <div class="cart-qty">

--- a/source/home.html
+++ b/source/home.html
@@ -181,7 +181,32 @@
                           {% assign hide_price = true %}
                         {% endif %}
                         {% unless hide_price %}
-                          {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                          {% assign show_strikethrough = false %}
+                          {% assign strikethrough_regular = nil %}
+                          {% assign strikethrough_sale = nil %}
+
+                          {% if theme.show_strikethrough_pricing %}
+                            {% if product.variable_pricing == false and product.original_price > product.default_price %}
+                              {% assign show_strikethrough = true %}
+                              {% assign strikethrough_regular = product.original_price %}
+                              {% assign strikethrough_sale = product.default_price %}
+                            {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and product.min_original_price > product.min_price %}
+                              {% assign show_strikethrough = true %}
+                              {% assign strikethrough_regular = product.min_original_price %}
+                              {% assign strikethrough_sale = product.min_price %}
+                            {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and product.max_original_price > product.max_price %}
+                              {% assign show_strikethrough = true %}
+                              {% assign strikethrough_regular = product.max_original_price %}
+                              {% assign strikethrough_sale = product.max_price %}
+                            {% endif %}
+                          {% endif %}
+
+                          {% if show_strikethrough %}
+                            <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+                            <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+                          {% else %}
+                            {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                          {% endif %}
 
                           {% if product.price_suffix != blank %}
                             {% assign variable_price_shown = true %}

--- a/source/home.html
+++ b/source/home.html
@@ -201,7 +201,7 @@
                       {% unless hide_price %}
                         {% if product.options.size > 1 and theme.show_product_variant_count_in_grid %}
                           <div class="product-list-thumb-options-description">
-                            {{ product.options.size }} {{ t['products.variants'] }}
+                            {{ product.options.size }} {{ t['products.variants'] | downcase }}
                           </div>
                         {% endif %}
                       {% endunless %}

--- a/source/javascripts/cart.js
+++ b/source/javascripts/cart.js
@@ -167,10 +167,13 @@ processUpdate = (input, item_id, new_val, cart) => {
   if (new_val > 0) {
     for (itemIndex = 0; itemIndex < cart.items.length; itemIndex++) {
       if (cart.items[itemIndex].id == item_id) {
-        item_price = cart.items[itemIndex].price;
-        formatted_item_price = formatMoney(item_price, true, true);
-        let priceElement = document.querySelector('.cart-item-price__update[data-item-id="'+item_id+'"]');
-        htmlHighlight(priceElement,formatted_item_price);
+        var item = cart.items[itemIndex];
+        var item_price = item.price;
+        var priceElement = document.querySelector('.cart-item-price__update[data-item-id="'+item_id+'"]');
+
+        // Line total only shows sale price (no strikethrough - strikethrough is on unit price only)
+        var formattedPrice = formatMoney(item_price, true, true);
+        htmlHighlight(priceElement, formattedPrice);
       }
     }
   }

--- a/source/javascripts/product-option-groups.js
+++ b/source/javascripts/product-option-groups.js
@@ -305,7 +305,7 @@ function processAvailableDropdownOptions(product, changed_dropdown) {
     if (product_option) {
       if (!product_option.sold_out && product_option.id > 0) {
         $('#option').val(product_option.id);
-        enableAddButton(product_option.price);
+        enableAddButton(product_option.price, product_option.original_price);
         if (num_option_groups > 1) {
           $('.reset-selection-button').fadeIn('fast');
         }

--- a/source/javascripts/product.js
+++ b/source/javascripts/product.js
@@ -29,8 +29,10 @@ if (themeOptions.productImageZoom === true) {
   lightbox.init();
 }
 $('.product_option_select').on('change',function() {
-  var option_price = $(this).find("option:selected").attr("data-price");
-  enableAddButton(option_price);
+  var selectedOption = $(this).find("option:selected");
+  var option_price = selectedOption.attr("data-price");
+  var original_price = selectedOption.attr("data-original-price");
+  enableAddButton(option_price, original_price);
 });
 
 function updateInventoryMessage(optionId = null) {
@@ -92,20 +94,44 @@ function updateInventoryMessage(optionId = null) {
   }
 }
 
-function enableAddButton(updated_price) {
+function enableAddButton(updated_price, original_price) {
   var addButton = $('.add-to-cart-button');
   var addButtonTitle = addButton.attr('data-add-title');
   addButton.attr("disabled",false);
+  // Button shows just the title, price is updated in the pricing area
+  addButton.html(addButtonTitle);
+  addButton.attr('aria-label', addButtonTitle);
+
+  // Update the price display area if a price is provided
   if (updated_price) {
-    priceTitle = ' - ' + formatMoney(updated_price, true, true);
+    updateProductPrice(updated_price, original_price);
   }
-  else {
-    priceTitle = '';
-  }
-  addButton.html(addButtonTitle + priceTitle);
-  addButton.attr('aria-label',addButton.text());
+
   updateInventoryMessage($('#option').val());
   showBnplMessaging(updated_price, { pageType: 'product' });
+}
+
+function updateProductPrice(updated_price, original_price) {
+  var priceContainer = $('.product-detail__price-value');
+  if (!priceContainer.length) return;
+
+  // Convert to numbers for proper comparison (data attributes are strings)
+  var updatedNum = parseFloat(updated_price) || 0;
+  var originalNum = parseFloat(original_price) || 0;
+
+  var showStrikethrough = originalNum > updatedNum &&
+                          themeOptions.showStrikethroughPricing;
+
+  var priceHtml;
+  if (showStrikethrough) {
+    var regularFormatted = formatMoney(original_price, true, true);
+    var saleFormatted = formatMoney(updated_price, true, true);
+    priceHtml = '<s class="price-compare">' + regularFormatted + '</s> <span class="price-sale">' + saleFormatted + '</span>';
+  } else {
+    priceHtml = formatMoney(updated_price, true, true);
+  }
+
+  priceContainer.html(priceHtml);
 }
 
 function disableAddButton(type) {

--- a/source/javascripts/product.js
+++ b/source/javascripts/product.js
@@ -102,10 +102,7 @@ function enableAddButton(updated_price, original_price) {
   addButton.html(addButtonTitle);
   addButton.attr('aria-label', addButtonTitle);
 
-  // Update the price display area if a price is provided
-  if (updated_price) {
-    updateProductPrice(updated_price, original_price);
-  }
+  updateProductPrice(updated_price, original_price);
 
   updateInventoryMessage($('#option').val());
   showBnplMessaging(updated_price, { pageType: 'product' });

--- a/source/javascripts/product.js
+++ b/source/javascripts/product.js
@@ -115,6 +115,17 @@ function updateProductPrice(updated_price, original_price) {
   var priceContainer = $('.product-detail__price-value');
   if (!priceContainer.length) return;
 
+  if (!updated_price) {
+    if (priceContainer.data('original-html') !== undefined) {
+      priceContainer.html(priceContainer.data('original-html'));
+    }
+    return;
+  }
+
+  if (priceContainer.data('original-html') === undefined) {
+    priceContainer.data('original-html', priceContainer.html());
+  }
+
   // Convert to numbers for proper comparison (data attributes are strings)
   var updatedNum = parseFloat(updated_price) || 0;
   var originalNum = parseFloat(original_price) || 0;

--- a/source/layout.html
+++ b/source/layout.html
@@ -307,7 +307,7 @@
           {% else %}
             <li><a href="/products">{{ t['navigation.products'] }}</a></li>
 
-            {% if show_pages_in_header %}
+            {% if show_custom_pages_in_header %}
               {% for custom_page in pages.custom_pages limit: theme.nav_items %}
                 <li>{{ custom_page | link_to }}</li>
               {% endfor %}

--- a/source/layout.html
+++ b/source/layout.html
@@ -624,6 +624,7 @@
         homeFeaturedVideoUrl: "{{ theme.home_featured_video_url }}",
         homeFeaturedVideoSize: "{{ theme.home_featured_video_size }}",
         homeFeaturedVideoBorder: "{{ theme.home_featured_video_border }}",
+        showStrikethroughPricing: {{ theme.show_strikethrough_pricing }},
       };
       const themeColors = {
         backgroundColor: '{{ theme.background_color }}',

--- a/source/layout.html
+++ b/source/layout.html
@@ -313,6 +313,10 @@
               {% endfor %}
             {% endif %}
 
+            {% if show_subscribe_in_header %}
+              <li class="artist-support"><a href="{{ pages.subscribe_page.url }}">{{ t['navigation.subscribe'] }}</a></li>
+            {% endif %}
+
             {% if show_contact_in_header %}
               <li><a href="/contact">{{ t['navigation.contact'] }}</a></li>
             {% endif %}

--- a/source/product.html
+++ b/source/product.html
@@ -45,9 +45,19 @@
                 {% endif %}
                   <img
                     alt="Image {{ forloop.index }} of {{ product.name | escape }}"
-                    class="product-image lazyload"
+                    class="product-image{% unless forloop.index == 1 %} lazyload{% endunless %}"
                     {% if forloop.index == 1 %}fetchpriority="high"{% else %}loading="lazy"{% endif %}
                     src="{{ image | product_image_url | constrain: 200 }}"
+                    {% if forloop.index == 1 %}
+                    srcset="
+                      {{ image | product_image_url | constrain: 400 }} 400w,
+                      {{ image | product_image_url | constrain: 700 }} 700w,
+                      {{ image | product_image_url | constrain: 1000 }} 1000w,
+                      {{ image | product_image_url | constrain: 1400 }} 1400w,
+                      {{ image | product_image_url | constrain: 2000 }} 2000w,
+                    "
+                    sizes="(min-width: 768px) 50vw, 100vw"
+                    {% else %}
                     data-srcset="
                       {{ image | product_image_url | constrain: 400 }} 400w,
                       {{ image | product_image_url | constrain: 700 }} 700w,
@@ -55,9 +65,10 @@
                       {{ image | product_image_url | constrain: 1400 }} 1400w,
                       {{ image | product_image_url | constrain: 2000 }} 2000w,
                     "
+                    data-sizes="auto"
+                    {% endif %}
                     width="{{ image.height | times: aspect_ratio }}"
                     height="{{ image.height }}"
-                    data-sizes="auto"
                   >
                 {% if theme.product_image_zoom %}</a>{% else %}</div>{% endif %}
               </div>
@@ -115,17 +126,17 @@
       {% endif %}
         <img
           alt="{{ product.name | escape }}"
-          class="blur-up product-image lazyload"
+          class="blur-up product-image"
           fetchpriority="high"
           src="{{ product.image | product_image_url | constrain: 200 }}"
-          data-srcset="
+          srcset="
             {{ product.image | product_image_url | constrain: 400 }} 400w,
             {{ product.image | product_image_url | constrain: 700 }} 700w,
             {{ product.image | product_image_url | constrain: 1000 }} 1000w,
             {{ product.image | product_image_url | constrain: 1400 }} 1400w,
             {{ product.image | product_image_url | constrain: 2000 }} 2000w,
           "
-          data-sizes="auto"
+          sizes="(min-width: 768px) 50vw, 100vw"
         >
       {% if theme.product_image_zoom %}</a>{% else %}</div>{% endif %}
     {% endif %}

--- a/source/product.html
+++ b/source/product.html
@@ -221,9 +221,7 @@
         {% endif %}
       </form>
     {% endif %}
-    {% if product.description != blank %}
-      <div class="product-detail__description">{{ product.description | paragraphs }}</div>
-    {% endif %}
+    <div class="product-detail__description" data-bc-hook="product-description">{%- if product.description != blank %}{{ product.description | paragraphs }}{% endif -%}</div>
 
   </section>
 </div>

--- a/source/product.html
+++ b/source/product.html
@@ -92,6 +92,7 @@
                 <img
                   alt=""
                   class="lazyload"
+                  loading="lazy"
                   src="{{ image | product_image_url | constrain: 150 }}"
                   data-srcset="
                     {{ image | product_image_url | constrain: 250 }} 250w,
@@ -330,6 +331,7 @@
                   <img
                     alt=""
                     class="blur-up product-list-image lazyload grid-{{ theme.grid_image_style }}"
+                    loading="lazy"
                     src="{{ related_product.image | product_image_url | constrain: 20 }}"
                     {% unless theme.grid_image_style == 'default' %}data-aspectratio="{{ aspect_ratio }}"{% endunless %}
                     data-srcset="

--- a/source/product.html
+++ b/source/product.html
@@ -134,20 +134,31 @@
   <section class="product-detail">
     <div class="product-detail__header">
       {% capture product_pricing %}
-        {{ product | product_price: theme.money_format }}
+        {% assign show_strikethrough = false %}
+        {% assign strikethrough_regular = nil %}
+        {% assign strikethrough_sale = nil %}
 
-        {% if product.price_suffix != blank %}
-          {% assign variable_price_shown = true %}
-          {% if theme.product_variable_pricing_display_format == "min_only" or theme.product_variable_pricing_display_format == "max_only" %}
-            {% assign variable_price_shown = false %}
+        {% if theme.show_strikethrough_pricing %}
+          {% if product.variable_pricing == false and product.original_price > product.default_price %}
+            {% assign show_strikethrough = true %}
+            {% assign strikethrough_regular = product.original_price %}
+            {% assign strikethrough_sale = product.default_price %}
+          {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and product.min_original_price > product.min_price %}
+            {% assign show_strikethrough = true %}
+            {% assign strikethrough_regular = product.min_original_price %}
+            {% assign strikethrough_sale = product.min_price %}
+          {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and product.max_original_price > product.max_price %}
+            {% assign show_strikethrough = true %}
+            {% assign strikethrough_regular = product.max_original_price %}
+            {% assign strikethrough_sale = product.max_price %}
           {% endif %}
+        {% endif %}
 
-          {% if product.variable_pricing and variable_price_shown %}
-            {% assign formatted_suffix = '(' | append: product.price_suffix | append: ')' %}
-          {% else %}
-            {% assign formatted_suffix = product.price_suffix %}
-          {% endif %}
-          <span class="price-suffix">{{ formatted_suffix }}</span>
+        {% if show_strikethrough %}
+          <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+          <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+        {% else %}
+          {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
         {% endif %}
       {% endcapture %}
       {% if product_status != blank %}<div class="product-detail__status {{ status_class }}">{{ product_status }}</div>{% endif %}
@@ -161,8 +172,26 @@
           {% assign hide_price = true %}
         {% endif %}
 
+        <span class="product-detail__price-value">
+          {% unless hide_price %}
+            {{ product_pricing }}
+          {% endunless %}
+        </span>
+
         {% unless hide_price %}
-          {{ product_pricing }}
+          {% if product.price_suffix != blank %}
+            {% assign variable_price_shown = true %}
+            {% if theme.product_variable_pricing_display_format == "min_only" or theme.product_variable_pricing_display_format == "max_only" %}
+              {% assign variable_price_shown = false %}
+            {% endif %}
+
+            {% if product.variable_pricing and variable_price_shown %}
+              {% assign formatted_suffix = '(' | append: product.price_suffix | append: ')' %}
+            {% else %}
+              {% assign formatted_suffix = product.price_suffix %}
+            {% endif %}
+            <span class="price-suffix">{{ formatted_suffix }}</span>
+          {% endif %}
         {% endunless %}
       </div>
       {% if product.status == "active" and theme.show_bnpl_messaging %}
@@ -191,7 +220,29 @@
                     <select data-unavailable-text="(Unavailable)" data-sold-text="({{ t['products.sold_out'] }})" data-group-id="{{ option_group.id }}" data-group-name="{{ option_group.name | escape }}" class="product_option_group" name="option_group[{{ option_group.id }}]" aria-label="Select {{ option_group.name | escape }}" required>
                       <option value="" disabled="disabled" selected>{{ option_group.name }}</option>
                       {% for value in option_group.values %}
-                        <option value="{{ value.id }}" data-name="{{ value.name | escape }}">{{ value.name }}</option>
+                        {% comment %}
+                          For single option groups, we can show status labels since each value maps to one product option.
+                          For multiple option groups, we can't know status until all selections are made.
+                        {% endcomment %}
+                        {% assign option_status_label = '' %}
+                        {% if product.option_groups.size == 1 %}
+                          {% for option in product.options %}
+                            {% for ogv in option.option_group_values %}
+                              {% if ogv.id == value.id %}
+                                {% if option.sold_out %}
+                                  {% assign option_status_label = t['products.sold_out'] | downcase %}
+                                {% elsif option.on_sale and theme.show_sale_label_in_product_options %}
+                                  {% assign option_status_label = t['products.on_sale'] | downcase %}
+                                {% elsif product.on_sale and option.original_price > option.price and theme.show_sale_label_in_product_options %}
+                                  {% comment %}Fallback: check product.on_sale and compare prices{% endcomment %}
+                                  {% assign option_status_label = t['products.on_sale'] | downcase %}
+                                {% endif %}
+                                {% break %}
+                              {% endif %}
+                            {% endfor %}
+                          {% endfor %}
+                        {% endif %}
+                        <option value="{{ value.id }}" data-name="{{ value.name | escape }}">{{ value.name }}{% if option_status_label != blank %} ({{ option_status_label }}){% endif %}</option>
                       {% endfor %}
                     </select>
                     <svg aria-hidden="true" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0.98 1.01 14.02 8.02"> <path d="M7.28125 8.71875L1.28125 2.71875C0.875 2.34375 0.875 1.6875 1.28125 1.3125C1.65625 0.90625 2.3125 0.90625 2.6875 1.3125L8 6.59375L13.2812 1.3125C13.6562 0.90625 14.3125 0.90625 14.6875 1.3125C15.0938 1.6875 15.0938 2.34375 14.6875 2.71875L8.6875 8.71875C8.3125 9.125 7.65625 9.125 7.28125 8.71875Z"></path> </svg>
@@ -203,7 +254,7 @@
                 <select class="product_option_select" id="option" name="cart[add][id]" aria-label="{{ t['products.select_variant'] }}" required>
                   <option value="" disabled="disabled" selected>{{ t['products.select_variant'] }}</option>
                   {% for option in product.options %}
-                    <option value="{{ option.id }}" data-price="{{ option.price }}"{% if option.sold_out %} disabled="disabled" disabled-type="sold-out"{% endif %}>{{ option.name }} {% if option.sold_out %} ({{ t['products.sold_out'] }}){% endif %}</option>
+                    <option value="{{ option.id }}" data-price="{{ option.price }}" data-original-price="{{ option.original_price }}" data-on-sale="{{ option.on_sale }}"{% if option.sold_out %} disabled="disabled" disabled-type="sold-out"{% endif %}>{{ option.name }}{% if option.sold_out %} ({{ t['products.sold_out'] | downcase }}){% elsif option.original_price > option.price and theme.show_sale_label_in_product_options %} ({{ t['products.on_sale'] | downcase }}){% endif %}</option>
                   {% endfor %}
                 </select>
                 <svg aria-hidden="true" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0.98 1.01 14.02 8.02"> <path d="M7.28125 8.71875L1.28125 2.71875C0.875 2.34375 0.875 1.6875 1.28125 1.3125C1.65625 0.90625 2.3125 0.90625 2.6875 1.3125L8 6.59375L13.2812 1.3125C13.6562 0.90625 14.3125 0.90625 14.6875 1.3125C15.0938 1.6875 15.0938 2.34375 14.6875 2.71875L8.6875 8.71875C8.3125 9.125 7.65625 9.125 7.28125 8.71875Z"></path> </svg>
@@ -297,7 +348,32 @@
                       {% assign hide_price = true %}
                     {% endif %}
                     {% unless hide_price %}
-                      {{ related_product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                      {% assign show_strikethrough = false %}
+                      {% assign strikethrough_regular = nil %}
+                      {% assign strikethrough_sale = nil %}
+
+                      {% if theme.show_strikethrough_pricing %}
+                        {% if related_product.variable_pricing == false and related_product.original_price > related_product.default_price %}
+                          {% assign show_strikethrough = true %}
+                          {% assign strikethrough_regular = related_product.original_price %}
+                          {% assign strikethrough_sale = related_product.default_price %}
+                        {% elsif related_product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and related_product.min_original_price > related_product.min_price %}
+                          {% assign show_strikethrough = true %}
+                          {% assign strikethrough_regular = related_product.min_original_price %}
+                          {% assign strikethrough_sale = related_product.min_price %}
+                        {% elsif related_product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and related_product.max_original_price > related_product.max_price %}
+                          {% assign show_strikethrough = true %}
+                          {% assign strikethrough_regular = related_product.max_original_price %}
+                          {% assign strikethrough_sale = related_product.max_price %}
+                        {% endif %}
+                      {% endif %}
+
+                      {% if show_strikethrough %}
+                        <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+                        <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+                      {% else %}
+                        {{ related_product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                      {% endif %}
 
                       {% if related_product.price_suffix != blank %}
                         {% assign variable_price_shown = true %}

--- a/source/product.html
+++ b/source/product.html
@@ -319,7 +319,7 @@
                   {% unless hide_price %}
                     {% if related_product.options.size > 1 and theme.show_product_variant_count_in_grid %}
                       <div class="product-list-thumb-options-description">
-                        {{ related_product.options.size }} {{ t['products.variants'] }}
+                        {{ related_product.options.size }} {{ t['products.variants'] | downcase }}
                       </div>
                     {% endif %}
                   {% endunless %}

--- a/source/products.html
+++ b/source/products.html
@@ -84,7 +84,32 @@
                   {% endif %}
 
                   {% unless hide_price %}
-                    {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                    {% assign show_strikethrough = false %}
+                    {% assign strikethrough_regular = nil %}
+                    {% assign strikethrough_sale = nil %}
+
+                    {% if theme.show_strikethrough_pricing %}
+                      {% if product.variable_pricing == false and product.original_price > product.default_price %}
+                        {% assign show_strikethrough = true %}
+                        {% assign strikethrough_regular = product.original_price %}
+                        {% assign strikethrough_sale = product.default_price %}
+                      {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and product.min_original_price > product.min_price %}
+                        {% assign show_strikethrough = true %}
+                        {% assign strikethrough_regular = product.min_original_price %}
+                        {% assign strikethrough_sale = product.min_price %}
+                      {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and product.max_original_price > product.max_price %}
+                        {% assign show_strikethrough = true %}
+                        {% assign strikethrough_regular = product.max_original_price %}
+                        {% assign strikethrough_sale = product.max_price %}
+                      {% endif %}
+                    {% endif %}
+
+                    {% if show_strikethrough %}
+                      <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+                      <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+                    {% else %}
+                      {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                    {% endif %}
 
                     {% if product.price_suffix != blank %}
                       {% assign variable_price_shown = true %}

--- a/source/products.html
+++ b/source/products.html
@@ -104,7 +104,7 @@
                 {% unless hide_price %}
                   {% if product.options.size > 1 and theme.show_product_variant_count_in_grid %}
                     <div class="product-list-thumb-options-description">
-                      {{ product.options.size }} {{ t['products.variants'] }}
+                      {{ product.options.size }} {{ t['products.variants'] | downcase }}
                     </div>
                   {% endif %}
                 {% endunless %}

--- a/source/settings.json
+++ b/source/settings.json
@@ -1350,6 +1350,25 @@
       }
     },
     {
+      "variable": "show_strikethrough_pricing",
+      "label": "Show strikethrough pricing",
+      "section": "product_page",
+      "type": "boolean",
+      "default": true,
+      "description": "Show the original price crossed out next to the sale price",
+      "requires": [
+        "feature:theme_strikethrough_pricing eq visible"
+      ]
+    },
+    {
+      "variable": "show_sale_label_in_product_options",
+      "label": "Show sale label in variant dropdowns",
+      "section": "product_page",
+      "type": "boolean",
+      "default": true,
+      "description": "Adds a sale indicator next to discounted variants in the dropdown"
+    },
+    {
       "variable": "product_variable_pricing_display_format",
       "label": "Price display for products with varying prices",
       "section": "product_page",

--- a/source/settings.json
+++ b/source/settings.json
@@ -798,7 +798,8 @@
       "options": [
         ["Default (Sentence case)", "initial"],
         ["Uppercase", "uppercase"],
-        ["Lowercase", "lowercase"]
+        ["Lowercase", "lowercase"],
+        ["Titlecase", "capitalize"]
       ],
       "default": "initial",
       "description": "Controls the text case styling in your main navigation"
@@ -811,7 +812,8 @@
       "options": [
         ["Default (Sentence case)", "initial"],
         ["Uppercase", "uppercase"],
-        ["Lowercase", "lowercase"]
+        ["Lowercase", "lowercase"],
+        ["Titlecase", "capitalize"]
       ],
       "default": "initial",
       "description": "Controls the text case styling in the footer, excluding custom footer text"

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Cosmos",
-  "version": "1.11.7",
+  "version": "1.12.0",
   "images": [
     {
       "variable": "logo_image",

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -57,7 +57,7 @@
   --side-padding: 40px
 
   --logo-max-height: #{"{{ theme.logo_image_height | append: 'px' }}"}
-  --logo-max-height-mobile: 120px
+  --logo-max-height-mobile: clamp(60px, calc(var(--logo-max-height) * 0.4), 150px)
 
   --shop-sprinkles-size: #{"{{ theme.shop_sprinkles_size | default: '2em' }}"}
   --shop-sprinkles-animation: #{"{% case theme.shop_sprinkles_animation %}{% when 'orbit' %}orbit{% when 'tumble' %}tumble{% else %}shake{% endcase %}"}

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -483,6 +483,7 @@ footer
       display: flex
       align-items: flex-start
       justify-content: flex-start
+      break-inside: avoid
 
       @media screen and (max-width: $break-small)
         padding-bottom: 16px

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -98,6 +98,9 @@
 .product-detail__description
   font-size: calc(1rem * var(--product-description-scale, 1))
 
+  &:empty
+    display: none
+
 .inventory-status-message
   color: var(--inventory-status-text-color)
   margin: 10px 0 auto

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -42,6 +42,11 @@
   .select
     margin: 0
 
+  select span, select span option
+    display: none
+    opacity: 0
+    visibility: hidden
+
 .product_option_groups
   display: flex
   flex-direction: column

--- a/source/stylesheets/products.sass
+++ b/source/stylesheets/products.sass
@@ -312,6 +312,12 @@ a.product-list-link
 .price-suffix
   white-space: nowrap
 
+// Strikethrough pricing styles
+.price-compare
+  text-decoration: line-through
+  opacity: 0.6
+  margin-right: 0.3em
+
 .pagination
   display: flex
   align-items: center


### PR DESCRIPTION
## Summary

### Features
- **Strikethrough pricing** — Display original prices with strikethrough when items are on sale
- **Titlecase nav text transformation** — New option to apply titlecase formatting to navigation text
- **Proportional mobile logo height** — Mobile logo height now scales proportionally with the desktop setting

### Fixes
- **Product description container always in DOM** — The product description container is now always rendered (with a `data-bc-hook`) so it can be targeted by JS, and hidden via CSS `:empty` when there's no description
- **Custom pages header visibility** — Custom pages now only show in the header when the corresponding setting is enabled
- **Subscribe link header display** — Subscribe link correctly appears in the header when available

### Chores
- Lowercase label for options text in product grid
- Version bump to 1.12.0